### PR TITLE
View now extends GenTraversableOnce.

### DIFF
--- a/src/test/scala/com/jsuereth/collections/ViewSpec.scala
+++ b/src/test/scala/com/jsuereth/collections/ViewSpec.scala
@@ -17,6 +17,7 @@ object ViewSpec extends Specification {
           take init                  $init
           forall test                $forall
           exists test                $exists
+          flatMap elements           $flatMap
   """
 
   def count = {
@@ -38,6 +39,13 @@ object ViewSpec extends Specification {
     val scalaView = orig.view.flatten.force
     val ourView = orig.stagedView.flatten.force
     ourView must beEqualTo(scalaView)
+  }
+
+  def flatMap = {
+    val orig = Vector(1,2,3)
+    val scalaView = orig.view.flatMap(x => (1 to x).toVector.view).force
+    val ourView = orig.stagedView.flatMap(x => (1 to x).toVector.stagedView).force
+    scalaView must beEqualTo(ourView)
   }
 
   def drop = {


### PR DESCRIPTION
This should allow views to be used inside flatMap operations.
We assume this is ok because GenTraversaleOnce has NO implementations of any methods, so we
need to always provide our own implementations.

TODO - We should check to see if GenTraversable[E] makes more sense to extend.  That one
has a few issues in terms of what it assumes (e.g. `repr`).

Review/Comments/Thoughts by @DarkDimius @ichoran @sethtisue
