### PR TITLE
Scala.js support for viewducers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/
+.js/
+.jvm/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: scala
 script:
   - sbt test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: scala
+script:
+  - sbt test
+jdk:
+  - openjdk8
+notifications:
+  email:
+    - joshua.suereth@typesafe.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 script:
   - sbt test
 jdk:
-  - openjdk8
+  - openjdk7
 notifications:
   email:
     - joshua.suereth@typesafe.com

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,9 @@ lazy val root =
     viewductionJVM, viewductionJS
   ).settings(
     publishTo := None,
-    publishLocal := ()
+    publishLocal := (),
+    sources in Compile := Nil,
+    sources in Test := Nil
   )
 
 lazy val viewduction =

--- a/build.sbt
+++ b/build.sbt
@@ -6,13 +6,24 @@ def commonSettings = Seq(
   isSnapshot := true,
   scalaVersion := "2.11.6",
   resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
-  libraryDependencies += "org.specs2" %% "specs2-core" % "2.4.14" % "test"
+  libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.0-M9" % "test"
 )
 
+lazy val root =
+  (project in file(".")).aggregate(
+    viewductionJVM, viewductionJS
+  ).settings(
+    publishTo := None,
+    publishLocal := ()
+  )
+
 lazy val viewduction =
-  (project in file(".")).settings(
+  (crossProject.crossType(CrossType.Pure) in file(".")).settings(
     name := "viewduction"
   ).settings(commonSettings:_*)
+
+lazy val viewductionJVM = viewduction.jvm
+lazy val viewductionJS = viewduction.js
 
 lazy val benchmarks =
   (project in file("benchmark")).settings(
@@ -21,9 +32,4 @@ lazy val benchmarks =
     testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework"),
     logBuffered := false,
     parallelExecution in Test := false
-  ).settings(commonSettings:_*).dependsOn(viewduction)
-
-
-
-
-
+  ).settings(commonSettings:_*).dependsOn(viewductionJVM)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.5")

--- a/src/test/scala/com/jsuereth/collections/ViewSpec.scala
+++ b/src/test/scala/com/jsuereth/collections/ViewSpec.scala
@@ -1,76 +1,62 @@
 package com.jsuereth.collections
 
-import org.specs2._
+import org.scalatest._
 import View.withExtensions
 
-object ViewSpec extends Specification {
-  override def is = s2"""
-       This is the specification for the View class.
-
-
-       The View class should
-          append elements with ++    $appendMultiple
-          count elements             $count
-          flatten nested collections $flatten
-          drop elements              $drop
-          find elements              $find
-          take init                  $init
-          forall test                $forall
-          exists test                $exists
-  """
-
-  def count = {
+class ViewSpec extends FunSuite with Matchers {
+  test("count") {
     val orig = List(1,2,3,4)
     val scalaView = orig.view.count(_ % 2 == 0)
     val ourView = orig.stagedView.count(_ % 2 == 0)
-    ourView must beEqualTo(scalaView)
+    ourView should equal(scalaView)
   }
 
-  def appendMultiple = {
+  test("appendMultiple") {
     val scalaView = (Vector(1,2,3).view ++ Vector(4)).force
     // TODO - ours should force too...
     val ourView = (Vector(1,2,3).stagedView ++ Vector(4))
-    ourView must beEqualTo(scalaView)
+    ourView should equal(scalaView)
   }
 
-  def flatten = {
+  test("flatten") {
     val orig = (Vector(Vector(1,2), Vector(3,4)))
     val scalaView = orig.view.flatten.force
     val ourView = orig.stagedView.flatten.force
-    ourView must beEqualTo(scalaView)
+    ourView should equal(scalaView)
   }
 
-  def drop = {
+  test("drop") {
     val orig = (1 to 20).to[scala.collection.mutable.ArrayBuffer]
     val scalaView = orig.view.drop(10).force
     val ourView = orig.stagedView.drop(10).force
-    ourView must beEqualTo(scalaView)
+    ourView should equal(scalaView)
   }
-  def find = {
+
+  test("find") {
     val orig = (1 to 20).to[scala.collection.mutable.Set]
     val scalaView = orig.view.find(_ % 2 == 0)
     val ourView = orig.stagedView.find(_ % 2 == 0)
-    ourView must beEqualTo(scalaView)
+    ourView should equal(scalaView)
   }
 
-  def init = {
+  test("init") {
     val orig = (1 to 20).to[scala.collection.mutable.ArrayBuffer]
     val scalaView = orig.view.init.force
     val ourView = orig.stagedView.init.force
-    ourView must beEqualTo(scalaView)
+    ourView should equal(scalaView)
   }
 
-  def forall = {
+  test("forall") {
     val orig = (1 to 20).to[scala.collection.immutable.List]
     val scalaView = orig.view.forall(_%2 !=3)
     val ourView = orig.stagedView.forall(_%2 !=3)
-    ourView must beEqualTo(scalaView)
+    ourView should equal(scalaView)
   }
 
-  def exists = {
+  test("exists") {
     val orig = (1 to 20).to[Vector]
     val scalaView = orig.view.exists(_ == 10)
     val ourView = orig.stagedView.exists(_==10)
-    ourView must beEqualTo(scalaView)
+    ourView should equal(scalaView)
   }
 }


### PR DESCRIPTION
Fixes up one minor nit from @sjrd's great work.

Additionally, adds .travis.yml for automated validation.

Replaces #2 
